### PR TITLE
Fix joint2 state interface param - fixes #2

### DIFF
--- a/scara_description/ros2_control/scara.ros2_control.urdf
+++ b/scara_description/ros2_control/scara.ros2_control.urdf
@@ -23,7 +23,7 @@
         <joint name="joint2">
             <command_interface name="position"/>
             <state_interface name="position">
-                <param name="initial_value">0.5.</param>
+                <param name="initial_value">0.5</param>
                 <param name="min">-1.57</param>
                 <param name="max">1.57</param>
             </state_interface>


### PR DESCRIPTION
The for the `position` interface the `initial_value` parameter has a trailing decimal point that should not be there. It makes the controller manager node crash at launch.